### PR TITLE
Add a link to the backlog and definition of done

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,17 @@
 # Lukuvinkkikirjasto
 
 Ohjelmointituotantokurssin miniprojekti
+
+## Backlogs
+https://github.com/akirataguchi115/lukuvinkkikirjasto/projects
+
+## Definition of done
+
+### All tasks
+- The task has been reviewed by at least one other
+team member
+
+### Coding tasks
+- The task has been junit tested (when it makes sense)
+- The task has been merged to the main branch
+


### PR DESCRIPTION
## Description (What and why)

Added a definition of done and a link to the project backlog. The definition of done defines broadly that when a task can be defined as done. Because of the link the backlog is easy to find. These were added because they were stated in the project requirements. Please comment if you have something to add or remove.

## How to test

No need to test.
