### PR TITLE
Have the database username and password to be defined as environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ https://github.com/akirataguchi115/lukuvinkkikirjasto/projects
 
 ## How to run
 
-`git clone` this repository. `cd` to the cloned repository and `./gradlew run` to start the application.
+`git clone` this repository. `cd` to the cloned repository and `export LUKUVINKKI_DB_USERNAME=<username_here> LUKUVINKKI_DB_PASSWORD=<password_here> && ./gradlew run`
+to start the application.
 
 Use `gradlew.bat` if you're using Windows.
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,8 +1,8 @@
 spring.datasource.driverClassName=org.h2.Driver
 
 spring.datasource.url=jdbc:h2:./database;
-spring.datasource.username=sa
-spring.datasource.password=sa
+spring.datasource.username=${LUKUVINKKI_DB_USERNAME}
+spring.datasource.password=${LUKUVINKKI_DB_PASSWORD}
 
 spring.datasource.initialization-mode=always
 


### PR DESCRIPTION
## Description
I changed the `application.properties` file so that the username and password are not shown there but they are given by the user when running the program. This is because usernames and passwords should not be in the source code. I also edited README so that the instructions fit the current situation.

## How to test:
Run the command `export LUKUVINKKI_DB_USERNAME=<username_here> LUKUVINKKI_DB_PASSWORD=<password_here> && ./gradlew run ` in the command line and check that the program runs the way it should.

If this pr is merged, it fixes #65 